### PR TITLE
Watch for dynamically added content within accordion body

### DIFF
--- a/components/UAccordion.vue
+++ b/components/UAccordion.vue
@@ -6,6 +6,10 @@ const props = defineProps<{
     modelValue: any,
     label?: string,
     value: any,
+    isFlat: {
+        type: boolean,
+        default: false,
+    }
 }>()
 const emit = defineEmits(['update:modelValue'])
 const bodyEl = ref()
@@ -49,7 +53,7 @@ defineExpose({updateHeight})
 </script>
 
 <template>
-    <div class="u-accordion card">
+    <div class="u-accordion card" :class="{'flat': isFlat}">
         <div class="header clickable p-3 align-items-center d-flex justify-content-between align-items-center"
              :class="{'border-b1': modelValue === value}"
              @click="toggle">
@@ -80,6 +84,10 @@ defineExpose({updateHeight})
                 transform: rotate(90deg);
             }
         }
+    }
+
+    &.flat {
+        box-shadow: none !important;
     }
 
     .body {

--- a/components/UAccordion.vue
+++ b/components/UAccordion.vue
@@ -26,6 +26,8 @@ function updateHeight() {
 
 watch(() => props.modelValue, updateHeight)
 onMounted(() => {
+    updateHeight()
+
     const observer = new MutationObserver(mutationsList => {
         for (const mutation of mutationsList) {
             if (mutation.type === 'childList') {

--- a/components/UAccordion.vue
+++ b/components/UAccordion.vue
@@ -24,8 +24,23 @@ function updateHeight() {
 }
 
 watch(() => props.modelValue, updateHeight)
-onMounted(updateHeight)
+onMounted(() => {
+    const observer = new MutationObserver(mutationsList => {
+        for (const mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                // Content of the div has changed, perform actions as needed
+                // You may also check for specific changes like node addition/removal
+                // and then respond accordingly
+                updateHeight();
+            }
+        }
+    });
 
+    observer.observe(bodyEl.value, {
+        childList: true,
+        subtree: true
+    });
+})
 defineExpose({ updateHeight })
 </script>
 

--- a/components/UAccordion.vue
+++ b/components/UAccordion.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import ArrowRightIcon from '../icons/ChevronRight.vue'
-import { onMounted, ref, watch } from 'vue'
+import {onMounted, ref, watch} from 'vue'
 
 const props = defineProps<{
     modelValue: any,
@@ -9,6 +9,7 @@ const props = defineProps<{
 }>()
 const emit = defineEmits(['update:modelValue'])
 const bodyEl = ref()
+const wrapperEl = ref()
 
 function toggle() {
     let emittedValue = props.modelValue === props.value ? null : props.value
@@ -17,7 +18,7 @@ function toggle() {
 
 function updateHeight() {
     if (props.modelValue === props.value) {
-        bodyEl.value.style.height = `${bodyEl.value.scrollHeight}px`
+        bodyEl.value.style.height = `${wrapperEl.value.scrollHeight}px`
     } else {
         bodyEl.value.style.height = 0
     }
@@ -41,7 +42,8 @@ onMounted(() => {
         subtree: true
     });
 })
-defineExpose({ updateHeight })
+
+defineExpose({updateHeight})
 </script>
 
 <template>
@@ -55,7 +57,9 @@ defineExpose({ updateHeight })
             <ArrowRightIcon class="icon" :class="{'opened': modelValue === value}"/>
         </div>
         <div ref="bodyEl" class="body">
-            <slot></slot>
+            <div class="wrapper" ref="wrapperEl">
+                <slot></slot>
+            </div>
         </div>
     </div>
 </template>

--- a/components/UChip.vue
+++ b/components/UChip.vue
@@ -2,7 +2,7 @@
 import { defineProps } from 'vue'
 
 const props = withDefaults(defineProps<{
-    color?: '' | 'primary' | 'secondary' | 'info' | 'danger',
+    color?: '' | 'primary' | 'secondary' | 'info' | 'danger'  | 'disabled',
 }>(), {
     color: '',
 })

--- a/components/UChoices.vue
+++ b/components/UChoices.vue
@@ -1,15 +1,15 @@
 <script lang="ts" setup>
 import UChip from './UChip.vue'
 import UInput from './UInput.vue'
-import { inputEmits, inputProps } from '../helpers/input-helper'
-import { computed, defineProps } from 'vue'
+import {inputEmits, inputProps} from '../helpers/input-helper'
+import {computed, defineProps} from 'vue'
 
 const props = defineProps({
     ...inputProps,
-    choices: { type: Array, default: () => [] },
-    multiple: { type: Boolean, default: false },
-    labelKey: { type: String, required: false, default: null },
-    labelFn: { type: Function, required: false },
+    choices: {type: Array, default: () => []},
+    multiple: {type: Boolean, default: false},
+    labelKey: {type: String, required: false, default: null},
+    disableFn: {type: Function, default: null}
 })
 const emit = defineEmits([...inputEmits])
 
@@ -23,7 +23,15 @@ function isSelected(choice) {
     return _value.value.includes(choice)
 }
 
+function isDisabled(choice) {
+    if (props.disableFn && typeof props.disableFn === 'function') {
+        return props.disableFn(choice)
+    }
+    return false
+}
+
 function onClick(choice) {
+    if (isDisabled(choice)) return;
     if (!props.multiple) {
         _value.value = choice
         return
@@ -35,12 +43,6 @@ function onClick(choice) {
     }
 }
 
-function getLabel(choice) {
-    if (props.labelFn) return props.labelFn(choice)
-    if (props.labelKey) return choice[props.labelKey]
-    return choice
-}
-
 </script>
 
 <template>
@@ -48,10 +50,11 @@ function getLabel(choice) {
         <div v-if="label" class="u-choices-label mb-2 text-small">{{ label }}</div>
         <div class="choices-list d-flex align-items-center flex-wrap gap-2">
             <UChip
+                :style="{cursor: isDisabled(choice) ? 'not-allowed' : 'pointer'}"
                 v-for="choice in choices"
                 @click="onClick(choice)"
-                :color="isSelected(choice) ? 'primary' : ''">
-                {{ getLabel(choice) }}
+                :color="isSelected(choice) ? 'primary' :  isDisabled(choice) ? 'disabled' : ''">
+                {{ labelKey ? choice[labelKey] : choice }}
             </UChip>
         </div>
     </UInput>

--- a/components/UChoices.vue
+++ b/components/UChoices.vue
@@ -9,6 +9,7 @@ const props = defineProps({
     choices: { type: Array, default: () => [] },
     multiple: { type: Boolean, default: false },
     labelKey: { type: String, required: false, default: null },
+    labelFn: { type: Function, required: false },
 })
 const emit = defineEmits([...inputEmits])
 
@@ -34,6 +35,12 @@ function onClick(choice) {
     }
 }
 
+function getLabel(choice) {
+    if (props.labelFn) return props.labelFn(choice)
+    if (props.labelKey) return choice[props.labelKey]
+    return choice
+}
+
 </script>
 
 <template>
@@ -44,7 +51,7 @@ function onClick(choice) {
                 v-for="choice in choices"
                 @click="onClick(choice)"
                 :color="isSelected(choice) ? 'primary' : ''">
-                {{ labelKey ? choice[labelKey] : choice }}
+                {{ getLabel(choice) }}
             </UChip>
         </div>
     </UInput>

--- a/components/UFileUpload.vue
+++ b/components/UFileUpload.vue
@@ -12,6 +12,7 @@ const props = withDefaults(defineProps<{
     disabled?: boolean,
     max?: number,
     multiple?: boolean,
+    label?: string
 }>(), {
     files: () => [],
     accept: null,
@@ -19,6 +20,7 @@ const props = withDefaults(defineProps<{
     disabled: false,
     max: Infinity,
     multiple: true,
+    label: ''
 })
 
 let dragActive = ref(false)
@@ -103,6 +105,7 @@ const emit = defineEmits(['change'])
                     <i v-if="disabled">file upload unavailable</i>
                     <i v-else-if="wrongType">incorrect file type</i>
                     <i v-else-if="dragActive">release to upload</i>
+                    <i v-else-if="label">{{ label }}</i>
                     <i v-else>drag &amp; drop here or click to upload files</i>
                 </div>
             </slot>

--- a/components/UFileUpload.vue
+++ b/components/UFileUpload.vue
@@ -11,12 +11,14 @@ const props = withDefaults(defineProps<{
     beforeChange?: ((file: File) => void | Promise<void>) | null,
     disabled?: boolean,
     max?: number,
+    multiple?: boolean,
 }>(), {
     files: () => [],
     accept: null,
     beforeChange: null,
     disabled: false,
     max: Infinity,
+    multiple: true,
 })
 
 let dragActive = ref(false)
@@ -87,7 +89,7 @@ const emit = defineEmits(['change'])
         <input
             v-show="false"
             type="file"
-            multiple
+            :multiple="multiple"
             @change="acceptUpload"
             ref="inputElement"
             :accept="accept"

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -36,5 +36,6 @@ $theme-colors: (
         "warning": $warning,
         "danger": $danger,
         "light": $light,
-        "dark": $dark
+        "dark": $dark,
+        "disabled": $disabled-text-color
 );


### PR DESCRIPTION
In a scenario where you're adding/toggling dynamic content within accordion body, the height is not automatically updated which results in either clipped overflow, or empty space. This PR fixes this issue.